### PR TITLE
Parse properties, superclass and conforming protocols

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -214,4 +214,72 @@ It has multiple lines`);
 			expect(methods[0].args[1].name).toBe("errorOrNil");
 		});
 	});
+
+	describe("withProperties", () => {
+		const withProperties = loadFile("withProperties");
+
+		it("should not fail with properties", () => {
+			expect(() => {
+				objcToJs(withProperties);
+			}).not.toThrow();
+		});
+
+		it("should extract all properties", () => {
+			const { properties } = objcToJs(withProperties);
+
+			const expectedProperties = [
+				{
+					name: "series",
+					type: "NSArray<NSString *>",
+					attributes: ["nonatomic", "readwrite"],
+				},
+				{
+					name: "colors",
+					type: "NSArray<UIColor*>",
+					attributes: ["nonatomic", "readwrite"],
+				},
+				{
+					name: "controllers",
+					type: "NSArray",
+					attributes: ["nonatomic", "readwrite"],
+				},
+				{
+					name: "title",
+					type: "NSString",
+					attributes: ["nonatomic", "readwrite"],
+				},
+				{
+					name: "isSet",
+					type: "NSNumber",
+					attributes: ["nonatomic", "readwrite"],
+				},
+			]
+
+			expect(properties).toStrictEqual(expectedProperties);
+		});
+
+	});
+
+	describe("withProtocols", () => {
+		const withProtocols = loadFile("withProtocols");
+
+		it("should not fail with protocols and superclass", () => {
+			expect(() => {
+				objcToJs(withProtocols);
+			}).not.toThrow();
+		});
+
+		it("should extract protocols", () => {
+			const { protocols } = objcToJs(withProtocols);
+
+			expect(protocols).toStrictEqual(["Nameable"]);
+		});
+
+		it("should extract superclass", () => {
+			const { superclass } = objcToJs(withProtocols);
+
+			expect(superclass).toBe("NSObject");
+		});
+
+	});
 });

--- a/exampleFiles/withProperties.h
+++ b/exampleFiles/withProperties.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface WithProperties : NSObject
+
+@property(nonatomic, readwrite) NSArray<NSString *> *series;
+
+@property(nonatomic, readwrite) NSArray<UIColor*> *colors;
+
+@property(nonatomic, readwrite) NSArray *controllers;
+
+@property(nonatomic, readwrite) NSString *title;
+
+@property(nonatomic, readwrite) NSNumber /* Bool */ *isSet;
+
+@end

--- a/exampleFiles/withProtocols.h
+++ b/exampleFiles/withProtocols.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@protocol Nameable
+
+@end
+
+@interface WithProtocols : NSObject <Nameable>
+
+@end

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const methodDeclarationRegex = /(?<!\s\*\s)(?:\+|\-)\s?\(((?:\s|\w|\<|\>|\*)*)\)
 const returnTypeRegex = /(?:\+|\-)\s?\(((?:\s|\w|\<|\>|\*)*)\)/;
 const argumentsRegex = /\s?\(((?:\w|\s|\*|\<|\>|\^|\(|\))*)\)\s*((?:\w)*)\s?/g;
 const commentRegex = /(?:^|\s)\/\/(.+?)$|\/\*(.*?)\*\//gms;
-const propertyDeclarationRegex = /(?:@property)\s?\(([\w,\s]+)\)\s?([\w\d\<\>\*]+)\s*\*?\s*([\w\d]+);/g;
+const propertyDeclarationRegex = /(?:@property)\s?\(([\w,\s]+)\)\s?([\w\d]+(?:\<[\w\d]+\s*\*?\>)?)\s*\*?\s*([\w\d]+);/g;
 
 // Get Groups for matches
 function getNthGroupForMatch(string, regex, index) {

--- a/index.js
+++ b/index.js
@@ -17,9 +17,23 @@ function getNthGroupForMatch(string, regex, index) {
 	return matches;
 }
 
+const parseClassName = file => {
+	const nameRegex = /@interface \w*/i;
+	const nameRegexLength = 11;
+	return (file.match(nameRegex) || [""])[0].substr(nameRegexLength);
+};
+
 const parseInterfaceDeclaration = file => {
 	const regex = new RegExp(interfaceDeclarationRegex);
 	const matches = regex.exec(file);
+	
+	if (!matches) {
+		const name = parseClassName(file);
+		return {
+			name
+		};
+	}
+
 	const [_interface, name, superclass, comaSeparatedProtocols] = matches;
 	
 	const protocols = (comaSeparatedProtocols ?? '')

--- a/index.js
+++ b/index.js
@@ -104,14 +104,15 @@ const parseMethods = file => {
 			return firstMethodLine === line.replace(/^\s+/g, "");
 		});
 
-		const isSingleLineComment = lines[lineIndex - 1].indexOf("//") !== -1;
+		const previousLine = lines[lineIndex - 1] ?? "";
+		const isSingleLineComment = previousLine.indexOf("//") !== -1;
 		const isSingleLineCommentInMultiLineCommentFormat =
-			lines[lineIndex - 1].indexOf("/**") !== -1 &&
-			lines[lineIndex - 1].lastIndexOf("*/") !== -1;
+			previousLine.indexOf("/**") !== -1 &&
+			previousLine.lastIndexOf("*/") !== -1;
 		const comment = isSingleLineComment
-			? lines[lineIndex - 1].replace(/\/\/(?:\s)*/, "")
+			? previousLine.replace(/\/\/(?:\s)*/, "")
 			: isSingleLineCommentInMultiLineCommentFormat
-			? lines[lineIndex - 1]
+			? previousLine
 					.replace(/\/\*\*(?:\s)*/, "")
 					.replace(/(?:\s)*\*+\//, "")
 			: extractMultiLineComment(lineIndex, lines);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const methodDeclarationRegex = /(?<!\s\*\s)(?:\+|\-)\s?\(((?:\s|\w|\<|\>|\*)*)\)
 const returnTypeRegex = /(?:\+|\-)\s?\(((?:\s|\w|\<|\>|\*)*)\)/;
 const argumentsRegex = /\s?\(((?:\w|\s|\*|\<|\>|\^|\(|\))*)\)\s*((?:\w)*)\s?/g;
 const commentRegex = /(?:^|\s)\/\/(.+?)$|\/\*(.*?)\*\//gms;
-const propertyDeclarationRegex = /(?:@property)\s?\(([\w,\s]+)\)\s?([\w\d]+(?:\<[\w\d]+\s*\*?\>)?)\s*\*?\s*([\w\d]+);/g;
+const propertyDeclarationRegex = /(?:@property)\s?\(([\w,\s]+)\)\s?([\w\d]+(?:\s?\<[\w\d]+\s*\*?\>)?)\s*\*?\s*([\w\d]+);/g;
 
 // Get Groups for matches
 function getNthGroupForMatch(string, regex, index) {

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,10 @@ fs.writeFileSync("/path/to/project/ponies.json", JSON.stringify(output));
 ```objective-c
 #import <Foundation/Foundation.h>
 @protocol Ponies, Foo;
-@interface BasicName : NSObject
+@interface BasicName : NSObject <Ponies, Foo>
 
 // Another comment
-@property(nonatomic, readonly) uninteresting<IgnorePlease> matcher;
+@property(nonatomic, readonly) NSArray<NSString *> titles;
 
 
 // This is the comment of basic method one
@@ -45,6 +45,15 @@ fs.writeFileSync("/path/to/project/ponies.json", JSON.stringify(output));
 ```json
 {
 	"name": "BasicName",
+	"superclass": "NSObject",
+	"protocols": ["Ponies", "Foo"],
+	"properties": [
+		{
+			"attributes": ["nonatomic", "readonly"],
+			"name": "titles",
+			"type": "NSArray<NSString *>"
+		}
+	],
 	"methods": [
 		{
 			"args": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz"
   integrity sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.8.0":
   version "7.24.7"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz"
   integrity sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==
@@ -592,6 +592,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz"
@@ -699,7 +704,12 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -736,7 +746,7 @@ asn1@~0.2.3:
   resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
   integrity sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=
 
-assert-plus@1.0.0, assert-plus@^1.0.0:
+assert-plus@^1.0.0, assert-plus@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
@@ -843,7 +853,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.22.2:
+browserslist@^4.22.2, "browserslist@>= 4.21.0":
   version "4.23.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz"
   integrity sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==
@@ -999,15 +1009,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colorette@^2.0.20:
   version "2.0.20"
@@ -1252,7 +1262,7 @@ extend@~3.0.2:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
+extsprintf@^1.2.0, extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
@@ -1389,7 +1399,19 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.4:
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1855,7 +1877,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@^29.7.0:
+jest-resolve@*, jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -2669,7 +2691,12 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
This PR aims to implement support for parsing @\property declarations, an interface’s superclass and conforming protocols.

The following header-file:
```objective-c
@interface BasicName : NSObject <Ponies, Foo>

// Another comment
@property(nonatomic, readonly) NSArray<NSString *> titles;


// This is the comment of basic method one
- (NSInteger)basicMethodOne;

@end
```
…will be parsed into:
```json
{
    "name": "BasicName",
    "superclass": "NSObject",
    "protocols": ["Ponies", "Foo"],
    "properties": [
        {
	    "attributes": ["nonatomic", "readonly"],
	    "name": "titles",
	    "type": "NSArray<NSString *>"
        }
    ],
    "methods": [
        {
	    "args": [],
	    "comment": "This is the comment of basic method one",
	    "name": "basicMethodOne",
	    "returnType": "NSInteger"
        }
    ]
}
```

Please let me know if there is anything you would like to change or supplement.